### PR TITLE
Modifying SYCL affinity example to remove LZ dependence

### DIFF
--- a/Examples/Aurora/affinity_gpu/sycl/Makefile
+++ b/Examples/Aurora/affinity_gpu/sycl/Makefile
@@ -8,7 +8,7 @@ CPP = cpp -P -traditional
 CPPFLAGS =
 
 LD = $(CXX)
-LIB = -lze_loader
+LIB =
 
 BINROOT=./
 EX=hello_affinity

--- a/Examples/Aurora/affinity_gpu/sycl/main.cpp
+++ b/Examples/Aurora/affinity_gpu/sycl/main.cpp
@@ -6,9 +6,8 @@
 #include <math.h>
 #include <time.h>
 #include <mpi.h>
-
+#include <iomanip>
 #include <sycl/sycl.hpp>
-#include <level_zero/ze_api.h>
 
 // xthi.c from http://docs.cray.com/books/S-2496-4101/html-S-2496-4101/cnlexamples.html
 
@@ -44,68 +43,15 @@ void get_cores(char *str)
   *ptr = 0;
 }
 
-// from Servesh
-#define MAX_UUID_STRING_SIZE    49
-static char hexdigit(int i)
-{
-  return (i>9) ? 'a' - 10 + i : '0' + i;
-}
-
-static void generic_uuid_to_string(const uint8_t * id, int bytes, char * s)
-{
-  for(int i=bytes-1; i>=0; --i) {
-    *s++ = hexdigit(id[i] / 0x10);
-    *s++ = hexdigit(id[i] % 0x10);
-    if(i >= 6 && i <= 12 && (i & 1) == 0) *s++ = '-';
+void uuid_print(std::array<unsigned char, 16> a){
+  std::cout << "GPU";
+  std::vector<std::tuple<int, int> > r = {{0,4}, {4,6}, {6,8}, {8,10}, {10,16}};
+  for (auto t : r){
+    std::cout << "-";
+    for (int i = std::get<0>(t); i < std::get<1>(t); i++)
+      std::cout << std::hex << std::setfill('0') << std::setw(2) << (unsigned)(unsigned char)a[i];
   }
-  *s = '\0';
-}
-
-void dev_uuid()
-{
-  // get vector of all available devices
-
-  std::vector<sycl::device> devices = sycl::device::get_devices();
-  int num_devices = devices.size();
-
-  uint32_t num_drivers = 0;
-  ze_driver_handle_t driverHandle;
-  zeDriverGet(&num_drivers, &driverHandle);
-
-  zeInit(ZE_INIT_FLAG_GPU_ONLY);
-
-  // print useful information for each device
-
-  int global_index = 0;
-  for(int i=0; i<num_devices; ++i) {
-
-    sycl::platform p = devices[i].get_platform();
-
-    std::string platform_name = p.get_info<sycl::info::platform::name>();
-    std::string device_name = devices[i].get_info<sycl::info::device::name>();
-    int device_id = devices[i].get_info<sycl::info::device::vendor_id>();
-
-    auto lz_dev = sycl::get_native<sycl::backend::ext_oneapi_level_zero>(devices[i]);
-
-    ze_device_properties_t dev_prop = {};
-    zeDeviceGetProperties(lz_dev, &dev_prop);
-
-    char type[256];
-    if(devices[i].is_gpu()) strcpy(type,"GPU");
-    else if(devices[i].is_accelerator()) strcpy(type,"ACCELERATOR");
-    else if(devices[i].is_cpu()) strcpy(type,"CPU");
-
-    char id[MAX_UUID_STRING_SIZE];
-    generic_uuid_to_string((const uint8_t *) &(dev_prop.uuid), ZE_MAX_DEVICE_UUID_SIZE, id);
-/*
-    printf(" [%i] Platform[%s] Type[%s] Device[%s, %i, %s]  lz uuid= %u",i,
-           platform_name.c_str(), type, 
-	   device_name.c_str(), device_id, id, 
-	   dev_prop.subdeviceId);
-*/
-    printf(" %s",id);
-  }
-
+  //  std::cout << std::endl;
 }
 
 int main(int argc, char *argv[])
@@ -121,9 +67,8 @@ int main(int argc, char *argv[])
 
   char nname[16];
   gethostname(nname, 16);
-  
-  // Initialize gpu
 
+  // make an array of all the devices available
   std::vector<sycl::device> devices = sycl::device::get_devices();
   int num_devices = devices.size();
 
@@ -134,11 +79,29 @@ int main(int argc, char *argv[])
         char list_cores[7*CPU_SETSIZE];
         get_cores(list_cores);
 
-        printf("To affinity and beyond!! nname= %s  rnk= %d  list_cores= (%s)  num_devices= %i  gpu_uuid= ",
+        printf("To affinity and beyond!! nname= %s  rnk= %d  list_cores= (%s)  num_devices= %i  gpu_uuids= ",
                nname, rnk, list_cores, num_devices);
-	dev_uuid();
 
-      printf("\n");
+
+      int device_index =0;
+      for(auto &device : devices) {
+
+	// Make a queue that can sends commands to each device.
+	// Note that if you make a queue like: "sycl::queue queue(sycl::gpu_selector_v)", you
+	// get one queue that feeds into one device as well.
+
+	sycl::queue q(device);
+        if (q.get_device().has(sycl::aspect::ext_intel_device_info_uuid)) {
+          uuid_print(q.get_device().get_info<sycl::ext::intel::info::device::uuid>());
+        }
+	else {
+	  std::cout << "No ability to get UUID from this device" ;
+	  }
+        device_index++;
+	if( device_index != num_devices ) std::cout << ", " ;
+
+      }
+	printf("\n");
     }
 
     MPI_Barrier(MPI_COMM_WORLD);

--- a/Examples/Aurora/affinity_gpu/sycl/main.cpp
+++ b/Examples/Aurora/affinity_gpu/sycl/main.cpp
@@ -44,10 +44,11 @@ void get_cores(char *str)
 }
 
 void uuid_print(std::array<unsigned char, 16> a){
-  std::cout << "GPU";
   std::vector<std::tuple<int, int> > r = {{0,4}, {4,6}, {6,8}, {8,10}, {10,16}};
+  int first_time = 0;
   for (auto t : r){
-    std::cout << "-";
+    if(first_time > 1) std::cout << "-";
+    first_time++;
     for (int i = std::get<0>(t); i < std::get<1>(t); i++)
       std::cout << std::hex << std::setfill('0') << std::setw(2) << (unsigned)(unsigned char)a[i];
   }


### PR DESCRIPTION
The GPU affinity example for SYCL for Aurora was getting the GPU UUIDs by invoking Level Zero. Instead of using that, we can now use an intel extension to SYCL and get the UUIDs in a simpler manner. The benefit of this is: 1) less code, 2) this will also execute correctly on Polaris as well (I tested it) so people can run the exact same on Nvidia systems with SYCL as well, and 3) for users that want to print the UUID from their own code, this is a much simpler way than using Level Zero, so they could copy and paste from here.

The output is nearly the same, but the characters in the UUIDs are flipped. The `uuid_print` function here is the same as that in other examples in the Polaris directory for this repo, like `Polaris/affinity_gpu/main.cpp` and `Polaris/ensemble/main.cpp`, so I liked using it to be consistent. I don't know if it matters too much as long as we have unique IDs but I can edit it to match the previous one if people prefer. (I liked the new version since it puts the "1" and "2" to designate which tile it is at the end of the string instead of the start.) 

Previously:

- Without gpu_tile_compact.sh:
```
> mpirun -n 2 ./hello_affinity 
To affinity and beyond!! nname= x1922c4s7b0n0  rnk= 1  list_cores= (1)  num_devices= 6  gpu_uuid=  00000000-0000-0000-db99-10551e7f667d 00000000-0000-0000-5b62-c4abd74d1941 00000000-0000-0000-3aba-5522a9f0dd20 00000000-0000-0000-c590-a61bb63088d4 00000000-0000-0000-1633-88e453e8161b 00000000-0000-0000-fbae-6c05b72c275b
To affinity and beyond!! nname= x1922c4s7b0n0  rnk= 0  list_cores= (0)  num_devices= 6  gpu_uuid=  00000000-0000-0000-db99-10551e7f667d 00000000-0000-0000-5b62-c4abd74d1941 00000000-0000-0000-3aba-5522a9f0dd20 00000000-0000-0000-c590-a61bb63088d4 00000000-0000-0000-1633-88e453e8161b 00000000-0000-0000-fbae-6c05b72c275b
```
- With gpu_tile_compact.sh:
```
> mpirun -n 6 gpu_tile_compact.sh ./hello_affinity 
To affinity and beyond!! nname= x1922c4s7b0n0  rnk= 0  list_cores= (0)  num_devices= 1  gpu_uuid=  01000000-0000-0000-db99-10551e7f667d
To affinity and beyond!! nname= x1922c4s7b0n0  rnk= 5  list_cores= (5)  num_devices= 1  gpu_uuid=  02000000-0000-0000-3aba-5522a9f0dd20
To affinity and beyond!! nname= x1922c4s7b0n0  rnk= 4  list_cores= (4)  num_devices= 1  gpu_uuid=  01000000-0000-0000-3aba-5522a9f0dd20
To affinity and beyond!! nname= x1922c4s7b0n0  rnk= 2  list_cores= (2)  num_devices= 1  gpu_uuid=  01000000-0000-0000-5b62-c4abd74d1941
To affinity and beyond!! nname= x1922c4s7b0n0  rnk= 3  list_cores= (3)  num_devices= 1  gpu_uuid=  02000000-0000-0000-5b62-c4abd74d1941
To affinity and beyond!! nname= x1922c4s7b0n0  rnk= 1  list_cores= (1)  num_devices= 1  gpu_uuid=  02000000-0000-0000-db99-10551e7f667d
```

With this branch:
- Without gpu_tile_compact.sh:
```
> mpirun -n 2 ./hello_affinity 
To affinity and beyond!! nname= x1922c4s7b0n0  rnk= 0  list_cores= (0)  num_devices= 6  gpu_uuids= 7d667f1e5510-99db-0000-000000000000, 41194dd7abc4-625b-0000-000000000000, 20ddf0a92255-ba3a-0000-000000000000, d48830b61ba6-90c5-0000-000000000000, 1b16e853e488-3316-0000-000000000000, 5b272cb7056c-aefb-0000-000000000000
To affinity and beyond!! nname= x1922c4s7b0n0  rnk= 1  list_cores= (1)  num_devices= 6  gpu_uuids= 7d667f1e5510-99db-0000-000000000000, 41194dd7abc4-625b-0000-000000000000, 20ddf0a92255-ba3a-0000-000000000000, d48830b61ba6-90c5-0000-000000000000, 1b16e853e488-3316-0000-000000000000, 5b272cb7056c-aefb-0000-000000000000
```
- With gpu_tile_compact.sh:
```
> mpirun -n 6 gpu_tile_compact.sh ./hello_affinity 
To affinity and beyond!! nname= x1922c4s7b0n0  rnk= 0  list_cores= (0)  num_devices= 1  gpu_uuids= 7d667f1e5510-99db-0000-000000000001
To affinity and beyond!! nname= x1922c4s7b0n0  rnk= 5  list_cores= (5)  num_devices= 1  gpu_uuids= 20ddf0a92255-ba3a-0000-000000000002
To affinity and beyond!! nname= x1922c4s7b0n0  rnk= 1  list_cores= (1)  num_devices= 1  gpu_uuids= 7d667f1e5510-99db-0000-000000000002
To affinity and beyond!! nname= x1922c4s7b0n0  rnk= 3  list_cores= (3)  num_devices= 1  gpu_uuids= 41194dd7abc4-625b-0000-000000000002
To affinity and beyond!! nname= x1922c4s7b0n0  rnk= 2  list_cores= (2)  num_devices= 1  gpu_uuids= 41194dd7abc4-625b-0000-000000000001
To affinity and beyond!! nname= x1922c4s7b0n0  rnk= 4  list_cores= (4)  num_devices= 1  gpu_uuids= 20ddf0a92255-ba3a-0000-000000000001
```

Let me know if there are comments or questions or anything to improve!

 